### PR TITLE
feat: add Datadog and Prometheus exporters

### DIFF
--- a/charts/ecommerce/templates/otel-collector-configmap.yaml
+++ b/charts/ecommerce/templates/otel-collector-configmap.yaml
@@ -12,9 +12,19 @@ data:
     exporters:
       logging:
         loglevel: debug
-      # Configure para enviar para Jaeger, Zipkin, Prometheus, etc
+      datadog:
+        api:
+          key: ${DD_API_KEY}
+          site: datadoghq.com
+      prometheus:
+        endpoint: "0.0.0.0:8889"
+        send_timestamps: true
+        metric_expiration: 60m
     service:
       pipelines:
         traces:
           receivers: [otlp]
-          exporters: [logging]
+          exporters: [logging, datadog]
+        metrics:
+          receivers: [otlp]
+          exporters: [logging, prometheus]

--- a/docs/images/docs_observabilidade_Version1.md
+++ b/docs/images/docs_observabilidade_Version1.md
@@ -14,7 +14,7 @@
 - **OpenTelemetry** implementado na aplicação para:
     - Tracing de requisições
     - Métricas customizadas (latência, erros, throughput)
-    - Exportação para Datadog/Grafana via Otel Collector
+    - Exportação para Datadog e Prometheus via Otel Collector
 
 ## Dashboards
 
@@ -24,7 +24,7 @@
 **Dashboard 2 - Monitora volume de erros 5xx no cluster**
 <img width="1451" height="701" alt="image" src="https://github.com/user-attachments/assets/73ba125c-b061-4512-99e1-c034e16776ef" />
 
-- **Datadog/Grafana** com:
+- **Datadog e Grafana (via Prometheus)** com:
     - Healthcheck dos componentes do cluster
     - Latência e disponibilidade da aplicação
     - Uso de CPU/RAM/pods


### PR DESCRIPTION
## Summary
- configure Datadog and Prometheus exporters for the Otel Collector
- document observability flow with the new exporters

## Testing
- `yamllint charts/ecommerce/templates/otel-collector-configmap.yaml` *(fails: Helm templating syntax not recognized)*
- `helm lint charts/ecommerce` *(fails: helm not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68940aefff0c8322b50be05793c3d666